### PR TITLE
test: fix test syntax for ASDFv3

### DIFF
--- a/cl-difflib-tests.asd
+++ b/cl-difflib-tests.asd
@@ -18,9 +18,7 @@
 
 (asdf:defsystem :cl-difflib-tests
     :depends-on (:cl-difflib)
-    :components ((:file "unit-tests")))
-
-(defmethod asdf:perform ((o asdf:test-op) (c (eql (find-system :cl-difflib-tests))))
-  (or (funcall (intern (symbol-name '#:run-tests)
-                       (find-package '#:difflib-test)))
-      (error "test-op failed")))
+    :components ((:file "unit-tests"))
+    :perform (test-op (o s)
+                      (unless (uiop:symbol-call :difflib-test '#:run-tests)
+                        (error "test-op failed"))))

--- a/cl-difflib.asd
+++ b/cl-difflib.asd
@@ -22,12 +22,8 @@
     :description "A Lisp library for computing differences between sequences."
     :long-description "A Lisp library for computing differences between sequences.  Based on Python's difflib module."
     
+    :in-order-to ((test-op (test-op "cl-difflib-tests")))
     :components ((:file "package")
 		 (:file "difflib" :depends-on ("package"))
 		 (:static-file "LICENSE.txt")
 		 (:static-file "NEWS.txt")))
-
-
-(defmethod perform ((o test-op) (c (eql (find-system 'cl-difflib))))
-  (oos 'load-op 'cl-difflib-tests)
-  (oos 'test-op 'cl-difflib-tests :force t))

--- a/unit-tests.lisp
+++ b/unit-tests.lisp
@@ -99,7 +99,8 @@
 	(test-similarity-ratio)
 	(test-close-matches)
 	(test-unified-diff)
-	(test-context-diff))
+	(test-context-diff)
+        (null *failed-tests*))
     (end-tests)))
 
 


### PR DESCRIPTION
Fix tests on ASDF v3. Fixes this error:

```
CL-USER> (ql:quickload "cl-difflib-tests")
CL-USER> (asdf:test-system :cl-difflib)
:FORCE and :FORCE-NOT arguments not allowed in a nested call to ASDF/OPERATE:OPERATE unless identically to toplevel
   [Condition of type UIOP/UTILITY:PARAMETER-ERROR]
```

Looping in @fare : could I request a review from you? Is this "the right way"?